### PR TITLE
Fix: Update instructions conda environment

### DIFF
--- a/{{cookiecutter.project_dir}}/README.rst
+++ b/{{cookiecutter.project_dir}}/README.rst
@@ -10,7 +10,7 @@ Getting started
 ---------------
 To set up your project, follow these steps:
 
-- :code:`conda env create -f conda_dependencies.yml -n {{cookiecutter.package_name}}`
+- :code:`conda env create -f conda_dependencies.yml`
 - :code:`conda activate {{cookiecutter.package_name}}`
 - :code:`python tasks/make_workspace.py --name <my_workspace> --resource_group <my_resource_group>`
 - :code:`python tasks/make_dataset.py --name <dataset_name> --input_file <my_data_file>`


### PR DESCRIPTION
This fixes #5 with new instructions in the README to correctly show people how to create an Anaconda environment.